### PR TITLE
Remove a User functionality

### DIFF
--- a/balance.py
+++ b/balance.py
@@ -46,7 +46,7 @@ def add_user(name):
     '''
     users = get_all_users()
     if name in users:
-        raise Exception("The user %s is already in the database." % name)
+        raise error("The user %s is already in the database." % name)
     cursor.execute('''INSERT INTO users VALUES (%s)''',
                    (name,))
     for user in users:
@@ -60,10 +60,10 @@ def remove_user(name):
     '''
     users = get_all_users()
     if name not in users:
-        raise Exception("The user %s is not in the database." % name)
+        raise error("The user %s is not in the database." % name)
     # See if there is an existing balance
     if not is_balance_free(name):
-        raise Exception("The user %s has an outstanding balance." % name)
+        raise error("The user %s has an outstanding balance." % name)
     cursor.execute('''DELETE FROM users WHERE name=%s''',
                    (name,))
     delete_old_balance(name)
@@ -223,7 +223,7 @@ def undo(record_id, delete=False):
 
     # Don't undo if a user doesn't exist
     if not is_user_exists(from_user) or not is_user_exists(to_user):
-        raise Exception("One of the given users don't exist. Cannot undo.")
+        raise error("One of the given users don't exist. Cannot undo.")
 
     update_balance(from_user, to_user, for_message, amount_str, log_record)
     return

--- a/balance.py
+++ b/balance.py
@@ -131,6 +131,14 @@ def is_balance_free(name):
     return True
 
 
+def is_user_exists(name):
+    '''
+    Determine whether a user exists.
+    '''
+    users = get_all_users()
+    return name in users
+
+
 def get_balance(from_user, to_user):
     '''
     Get the amount PERSON1 owes PERSON2.
@@ -206,6 +214,9 @@ def undo(record_id, delete=False):
     to_user = record[4]
     for_message = "UNDO %d" % record_id
     amount_str = str(-1 * record[6])
+
+    if not is_user_exists(from_user) or not is_user_exists(to_user):
+        raise Exception("One of the given users don't exist. Cannot undo.")
 
     if delete:
         cursor.execute('''DELETE FROM balance_logs where id=%s''', (record_id))

--- a/balance.py
+++ b/balance.py
@@ -46,7 +46,7 @@ def add_user(name):
     '''
     users = get_all_users()
     if name in users:
-        raise error("The user %s is already in the database." % name)
+        error("The user %s is already in the database." % name)
     cursor.execute('''INSERT INTO users VALUES (%s)''',
                    (name,))
     for user in users:
@@ -60,10 +60,10 @@ def remove_user(name):
     '''
     users = get_all_users()
     if name not in users:
-        raise error("The user %s is not in the database." % name)
+        error("The user %s is not in the database." % name)
     # See if there is an existing balance
     if not is_balance_free(name):
-        raise error("The user %s has an outstanding balance." % name)
+        error("The user %s has an outstanding balance." % name)
     cursor.execute('''DELETE FROM users WHERE name=%s''',
                    (name,))
     delete_old_balance(name)
@@ -223,7 +223,7 @@ def undo(record_id, delete=False):
 
     # Don't undo if a user doesn't exist
     if not is_user_exists(from_user) or not is_user_exists(to_user):
-        raise error("One of the given users don't exist. Cannot undo.")
+        error("One of the given users don't exist. Cannot undo.")
 
     update_balance(from_user, to_user, for_message, amount_str, log_record)
     return

--- a/balance.py
+++ b/balance.py
@@ -126,7 +126,7 @@ def is_balance_free(name):
     '''
     users = get_all_users()
     for user in users:
-        if get_balance(name, user) or get_balance(user, name):
+        if get_balance(name, user) > 0.01 or get_balance(user, name) > 0.01:
             return False
     return True
 

--- a/balance.py
+++ b/balance.py
@@ -215,14 +215,16 @@ def undo(record_id, delete=False):
     for_message = "UNDO %d" % record_id
     amount_str = str(-1 * record[6])
 
-    if not is_user_exists(from_user) or not is_user_exists(to_user):
-        raise Exception("One of the given users don't exist. Cannot undo.")
-
     if delete:
         cursor.execute('''DELETE FROM balance_logs where id=%s''', (record_id))
 
     # If delete, then don't log_record.
     log_record = not delete
+
+    # Don't undo if a user doesn't exist
+    if not is_user_exists(from_user) or not is_user_exists(to_user):
+        raise Exception("One of the given users don't exist. Cannot undo.")
+
     update_balance(from_user, to_user, for_message, amount_str, log_record)
     return
 

--- a/balance.py
+++ b/balance.py
@@ -379,13 +379,13 @@ def print_examples():
     <code>filter [FIELD=VALUE]+</code>
     <br />
     <br />
-    <code>add [USER]+</code> (admin-only)
+    <code>add_user [USER]+</code> (admin-only)
     <br />
     <br />
     <code>delete [LOG_ID]+</code> (admin-only)
     <br />
     <br />
-    <code>remove [USER]+</code> (admin-only)
+    <code>remove_user [USER]+</code> (admin-only)
     <br />
     <br />
 
@@ -550,7 +550,7 @@ if __name__ == '__main__':
         print_balance()
     elif command_split[0] == 'print_logs':
         print_logs()
-    elif command_split[0] == 'add':
+    elif command_split[0] == 'add_user':
         if username not in settings.admin_users:
             error("only admin users can add users.")
         add_list = command_split[1:]
@@ -561,7 +561,7 @@ if __name__ == '__main__':
             error("only admin users can delete records")
         for record_id in command_split[1:]:
             undo(int(record_id), delete=True)
-    elif command_split[0] == 'remove':
+    elif command_split[0] == 'remove_user':
         if username not in settings.admin_users:
             error("only admin users can remove users")
         for user in command_split[1:]:


### PR DESCRIPTION
Implemented said feature in this pull request.
- The user is removed from the database along with blank records of owing.
- If the user owes someone money, this will terminate.
- If the user is owed money by someone, this will terminate.
- This is an admin-only command.
- This command can only be performed on an existing user.
- Old transaction logs involving this user will be kept. Undos cannot be done on these transactions but logs can be deleted.

This fixes #15.
